### PR TITLE
Perbarui list dan keterangan ke versi saat ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A list of awesome groups related to programming language on Telegram.
 ### DevOps
 * [IDDevOps](https://t.me/IDDevOps)
 * [Docker.id](https://t.me/dockerid)
+* [ServerLess Tech](https://t.me/ServerlessTech)
 
 ### Big Data
 * [Big Data Indonesia](https://t.me/bigdataID)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A list of awesome groups related to programming language on Telegram.
 ### Development
 * [Frontend Developer Indonesia](https://t.me/FrontEndID)
 * [SinauDev - Sinau Development](https://t.me/sinaudev)
-* [Odoo-OpenERP Indonesia](https://t.me/odooindonesia)
+* [Odoo - OpenERP Indonesia](https://t.me/odooindonesia)
 * [Tech in Asia Dev Community](https://t.me/TIAdevcommunity)
 * [Kongkow IT Medan](https://t.me/kongkowITMedan)
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Listed by *Hendi Santika*
 - Email: hendisantika@gmail.com
-- Telegram: https://t.me/hendisantika34
+- Telegram: [@hendisantika34](https://t.me/hendisantika34)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A list of awesome groups related to programming language on Telegram.
   + [JVM User Group](https://t.me/JVMUserGroup)
 
 * **Kotlin**
-  + [Kotlin User Group](https://t.me/KotlinID)
+  + [Kotlin Indonesia](https://t.me/KotlinID)
 
 * **JavaScript**
   + [Angular Indonesia](https://t.me/AngularID)

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ A list of awesome groups related to programming language on Telegram.
   + [SANDEC (Semarang Android Developer Center)](https://t.me/AndroidSemarang)
   + [Belajar Bareng Android Jakarta](https://t.me/BelajarBarengAndroid)
   + [Yogyakarta Android Community](https://t.me/YogyakartaAndroidComunity)
-  
+
 * **Microsoft**
   + [dotnet.id](https://t.me/dotnetusergroup)
   + [Xamarin Indonesia](https://t.me/xamarinindonesia)
 
 * **Elixir**
   + [Elixir ID](https://t.me/elixir_id)
-  
+
 * **Golang**
   + [Golang Indonesia](https://t.me/golangID)
 
@@ -27,7 +27,7 @@ A list of awesome groups related to programming language on Telegram.
 
 * **Kotlin**
   + [Kotlin User Group](https://t.me/KotlinID)
-  
+
 * **JavaScript**
   + [Angular Indonesia](https://t.me/AngularID)
   + [Nodejs Indonesia](https://t.me/nodejsid)
@@ -38,27 +38,27 @@ A list of awesome groups related to programming language on Telegram.
 
 * **Pascal**
   + [Pascal Indonesia](https://t.me/PascalID)
-  
+
 * **PHP**
   + [Laravel Indonesia](https://t.me/laravelindonesia)
   + [Symfony Framework Indonesia](https://t.me/symfonyid)
   + [CodeIgniter Indonesia](https://t.me/codeigniterindonesia)
   + [Yii Framework Indonesia](https://t.me/YiiFrameworkIndonesia)
   + [PHP Indonesia for Student](https://t.me/PHPIDforStudent)
-  
+
 * **Python**
   + [Python ID](https://t.me/pythonID)
   + [Surabaya.py](https://t.me/surabayadotpy)
   + [Django Indonesia](https://t.me/DjangoID)
   + [Flask ID](https://t.me/flaskid)
-  
+
 * **Ruby**
   + [Ruby Indonesia](https://t.me/ruby_id)
   + [Rails Indonesia](https://t.me/RailsID)
 
 * **Swift**
   + [Swift Indonesia](https://t.me/swiftID)
-  
+
 ### IOT
 * [Raspberry PI Indonesia](https://t.me/raspberrypi_id)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ A list of awesome groups related to programming language on Telegram.
   + [ADB (Android Developer Bandung)](https://t.me/androidDevBdg)
   + [SANDEC (Semarang Android Developer Center)](https://t.me/AndroidSemarang)
   + [Belajar Bareng Android Jakarta](https://t.me/BelajarBarengAndroid)
-  + [Yogyakarta Android Community](https://t.me/YogyakartaAndroidComunity)
 
 * **Microsoft**
   + [dotnet.id](https://t.me/dotnetusergroup)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Awesome Telegram Groups
+# Awesome Indonesia Telegram Groups
 
-A list of awesome groups related to programming language on Telegram.
+A list of awesome indonesia groups related to programming language on Telegram.
 
 ## List
 


### PR DESCRIPTION
Hai @hendisantika!
Dengan adanya isu #15 yang mengira ini adalah daftar grup internasional, saya merubah beberapa keterangan menjadi daftar grup indonesia.

Perubahan lainnya:
- Menambahkan daftar baru yaitu `ServerLess Tech`.
- Memperbarui nama `Kotlin User Group` menjadi `Kotlin Indonesia`.
- Menghapus `@YogyakartaAndroidComunity` karena grup tidak ditemukan.
- Dan beberapa perbaikan lainnya. 

Edit: PR ini juga mengacu pada isu #12.