### PR TITLE
Change link macOS group based on group info

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ A list of awesome Indonesia groups related to programming language on Telegram.
 * [WINDOWS SERVER INDONESIA](https://t.me/WindServID)
 
 ### MacOS
-* [Mac OS X ID](https://t.me/MacOSXID)
+* [Mac OS X ID](https://t.me/MacOSXIDGroup)
 
 ### iOS
 * [iKaskus](https://t.me/ikaskus)


### PR DESCRIPTION
I found this ini the group description
![image](https://user-images.githubusercontent.com/13099373/84784282-5596c480-b014-11ea-96f2-96183bc3f8db.png)
