### PR TITLE
update: add a GNU/Weeb for the Linux group

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ A list of awesome Indonesian groups related to a programming language on Telegra
 - [Elementary OS Indonesia](https://t.me/elementaryID)
 - [Fedora Indonesia](https://t.me/FedoraID)
 - [GNOME Indonesia](https://t.me/gnomeid)
+- [GNU/Weeb](https://t.me/GNUWeeb)
 - [Kali Linux Indonesia](https://t.me/KaliLinuxID)
 - [KDE Indonesia](https://t.me/kdeid)
 - [Komunitas GNU/Linux Malang](https://t.me/linuxmalang)
@@ -410,7 +411,7 @@ A list of awesome Indonesian groups related to a programming language on Telegra
 
 - **.NET**
 
-  - [.NET Indonesia](https://t.me/dotnetusergroup)  
+  - [.NET Indonesia](https://t.me/dotnetusergroup)
   - [One .NET Indonesia](https://t.me/dotnetcore_id)
   - [Xamarin Indonesia](https://t.me/xamarinindonesia)
 


### PR DESCRIPTION
GNU/Weeb is an Indonesian GNU Linux group, this group is talking about Linux kernel or GNU related. Many group members are anime fans that's why the group name contain `Weeb` word. This group usually use English on weekend especially Sunday, but they also talk Indonesian language.

Signed-off-by: Muhammad Rizki <kiizuha@gnuweeb.org>