### PR TITLE
replace ubuntu channel link with group link

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ A list of awesome Indonesian groups related to a programming language on Telegra
 - [Paguyuban Linux Solo](https://t.me/linuxsolo)
 - [ParrotSec Indonesia](https://t.me/parrotsecurityindonesia)
 - [Red Hat Enterprise Linux ID](https://t.me/rhel_id)
-- [Ubuntu Indonesia](https://t.me/ubuntu_id)
+- [Ubuntu Indonesia](https://t.me/ubuntu_indo)
 - [Void Linux Indonesia](https://t.me/voidlinux_id)
 </details>
 


### PR DESCRIPTION
Saya ijin mengubah link atau URL dari Ubuntu Indonesia. 

Alasan:
Link yang saat ini tercantum merupakan link channel Telegram dari Ubuntu Indonesia, bukan grup diskusi dari Ubuntu Indonesia. Sehingga saya menggantinya dengan link yang seharusnya merupakan grup Telegram Ubuntu Indonesia. 

Mohon tinjauannya. Terima kasih.